### PR TITLE
JENKINS-19279 checkUrl not escaped making job config ui unusable

### DIFF
--- a/src/main/resources/pojelly/textarea.jelly
+++ b/src/main/resources/pojelly/textarea.jelly
@@ -67,7 +67,7 @@
   <textarea id="${attrs.id}" style="${attrs.style}"
             name ="${attrs.name ?: '_.'+attrs.field}"
             class="setting-input ${attrs.checkUrl!=null?'validated':''} ${attrs.class}"
-            checkUrl="${attrs.checkUrl}"
+            checkUrl="'${attrs.checkUrl}'"
             rows="${numRows}">
     <st:out value="${value}" />
   </textarea>


### PR DESCRIPTION
 if e.g. publish over ssh plugin is installed.  Not sure this is the correct way
to fix it. ( wrapped ${attr.checkUrl} in textarea.jelly with '  )
