### PR TITLE
Added additional setters and constructors for pipeline support

### DIFF
--- a/src/main/java/jenkins/plugins/publish_over/BPInstanceConfig.java
+++ b/src/main/java/jenkins/plugins/publish_over/BPInstanceConfig.java
@@ -96,6 +96,9 @@ public class BPInstanceConfig<PUBLISHER extends BapPublisher> implements Seriali
     public ParamPublish getParamPublish() {
         return paramPublish;
     }
+    public void setParamPublish(final ParamPublish paramPublish) {
+        this.paramPublish = paramPublish;
+    }
 
     public BPHostConfiguration getConfiguration(final String configName) {
         final BPHostConfiguration config = hostConfigurationAccess.getConfiguration(configName);

--- a/src/main/java/jenkins/plugins/publish_over/BPPlugin.java
+++ b/src/main/java/jenkins/plugins/publish_over/BPPlugin.java
@@ -55,12 +55,20 @@ public abstract class BPPlugin<PUBLISHER extends BapPublisher, CLIENT extends BP
     private final String consolePrefix;
     private BPInstanceConfig delegate;
 
+    public BPPlugin(final String consolePrefix) {
+        this(consolePrefix, new BPInstanceConfig<PUBLISHER>());
+    }
+
     public BPPlugin(final String consolePrefix, final ArrayList<PUBLISHER> publishers, final boolean continueOnError,
                     final boolean failOnError, final boolean alwaysPublishFromMaster, final String masterNodeName,
                     final ParamPublish paramPublish) {
-        this.delegate = new BPInstanceConfig<PUBLISHER>(publishers, continueOnError, failOnError, alwaysPublishFromMaster, masterNodeName,
-                                                        paramPublish);
-        delegate.setHostConfigurationAccess(this);
+        this(consolePrefix, new BPInstanceConfig<PUBLISHER>(
+                publishers, continueOnError, failOnError, alwaysPublishFromMaster, masterNodeName, paramPublish));
+    }
+
+    private BPPlugin(final String consolePrefix, BPInstanceConfig delegate) {
+        this.delegate = delegate;
+        this.delegate.setHostConfigurationAccess(this);
         this.consolePrefix = consolePrefix;
     }
 


### PR DESCRIPTION
I added the setter setParamPublish to BPInstanceConfig to fix an issue with the pipeline step in publish-over-cifs used in a declarative pipeline.

In addition I added a constructor with less parameters to BPPlugin.