### PR TITLE
Fixed interaction with the latest promoted-builds jenkins plugin

### DIFF
--- a/src/main/java/jenkins/plugins/publish_over/BPPlugin.java
+++ b/src/main/java/jenkins/plugins/publish_over/BPPlugin.java
@@ -107,8 +107,8 @@ public abstract class BPPlugin<PUBLISHER extends BapPublisher, CLIENT extends BP
         if (PROMOTION_CLASS_NAME.equals(build.getClass().getCanonicalName())) {
             AbstractBuild<?, ?> promoted;
             try {
-                final Method getTarget = build.getClass().getMethod("getTarget", (Class<?>[]) null);
-                promoted = (AbstractBuild) getTarget.invoke(build, (Object[]) null);
+                final Method getTargetBuild = build.getClass().getMethod("getTargetBuild", (Class<?>[]) null);
+                promoted = (AbstractBuild) getTargetBuild.invoke(build, (Object[]) null);
             } catch (Exception e) {
                 throw new RuntimeException(Messages.exception_failedToGetPromotedBuild(), e);
             }


### PR DESCRIPTION
### Original issue:
Jenkins promotion fails after upgrading promoted-builds-plugin (https://github.com/jenkinsci/promoted-builds-plugin) from **3.11** to **867.v7c3a_b_83a_eb_79** (https://github.com/jenkinsci/promoted-builds-plugin/releases/tag/867.v7c3a_b_83a_eb_79) version. 

### Jenkins promotion's console output:
`ERROR: Exception when publishing, exception message [The base directory does not exist. If this is a promotion, have you "Archived the artifacts"?]`

### Related jira tickets:
[JENKINS-22731](https://issues.jenkins.io/browse/JENKINS-22731)
[JENKINS-60020](https://issues.jenkins.io/browse/JENKINS-60020)

### Related pull request:
The "getTarget" method was removed here from promoted-builds plugin: https://github.com/jenkinsci/promoted-builds-plugin/pull/159

### Solution:
Updating "getTarget" reflective method call in BPPlugin class to "getTargetBuild", because in promoted-builds-plugin (https://github.com/jenkinsci/promoted-builds-plugin) the (deprecated) "getTarget" method was deleted in **867.v7c3a_b_83a_eb_79**
(https://github.com/jenkinsci/promoted-builds-plugin/releases/tag/867.v7c3a_b_83a_eb_79) release.

Now the latest promoted-builds-plugin uses the "getTargetBuild" method instead of "getTarget". Applying these changes it will be also backward compatible, because the "older" versions of promoted-builds plugin contains the "getTargetBuild" and "getTarget" methods too.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
