### PR TITLE
Bump parent pom to 4.53, java to 11 and Jenkins to 2.361.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ target/
 .settings/
 .classpath
 .project
+work/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,7 @@
-buildPlugin()
+buildPlugin(
+  useContainerAgent: true,
+  configurations: [
+    [platform: 'linux', jdk: 17],
+    [platform: 'windows', jdk: 11],
+  ]
+)

--- a/pom.xml
+++ b/pom.xml
@@ -29,18 +29,18 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.50</version>
+        <version>4.53</version>
     </parent>
 
     <artifactId>publish-over</artifactId>
     <packaging>hpi</packaging>
     <name>Infrastructure plugin for Publish Over X</name>
     <version>0.23-SNAPSHOT</version>
-    <description>Send build artifacts somewhere.</description>
 
     <properties>
-        <java.level>8</java.level>
+        <java.level>11</java.level>
         <java.net.id>bap</java.net.id>
+        <jenkins.version>2.361.4</jenkins.version>
     </properties>
 
     <licenses>
@@ -98,7 +98,7 @@
     </dependencies>
 
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/publish-over-plugin.git</connection>
+        <connection>scm:git:https://github.com/jenkinsci/publish-over-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/publish-over-plugin.git</developerConnection>
         <tag>HEAD</tag>
     </scm>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<div>
+	Send build artifacts somewhere.
+</div>


### PR DESCRIPTION
Changed connection url from deprecated git protocol to HTTPS

Move description from pom.xml to index.jelly as indicated by hpi plugin:
> Delete any <description> from pom.xml and create src/main/resources/index.jelly

https://www.jenkins.io/blog/2022/12/14/require-java-11/

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] ~~Link to relevant issues in GitHub or Jira~~
- [x] ~~Link to relevant pull requests, esp. upstream and downstream changes~~
- [x] ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~
