### PR TITLE
Add Serializable bound to COMMON_CONFIG generic type parameter

### DIFF
--- a/src/main/java/jenkins/plugins/publish_over/BPHostConfiguration.java
+++ b/src/main/java/jenkins/plugins/publish_over/BPHostConfiguration.java
@@ -35,7 +35,7 @@ import java.io.IOException;
 import java.io.Serializable;
 
 @SuppressWarnings("PMD.TooManyMethods")
-public abstract class BPHostConfiguration<CLIENT extends BPClient, COMMON_CONFIG> implements Serializable {
+public abstract class BPHostConfiguration<CLIENT extends BPClient, COMMON_CONFIG extends Serializable> implements Serializable {
 
     private static final long serialVersionUID = 1L;
 

--- a/src/main/java/jenkins/plugins/publish_over/BPHostConfigurationAccess.java
+++ b/src/main/java/jenkins/plugins/publish_over/BPHostConfigurationAccess.java
@@ -26,6 +26,6 @@ package jenkins.plugins.publish_over;
 
 import java.io.Serializable;
 
-public interface BPHostConfigurationAccess<CLIENT extends BPClient, COMMON_CONFIG> extends Serializable {
+public interface BPHostConfigurationAccess<CLIENT extends BPClient, COMMON_CONFIG extends Serializable> extends Serializable {
     BPHostConfiguration<CLIENT, COMMON_CONFIG> getConfiguration(String name);
 }

--- a/src/main/java/jenkins/plugins/publish_over/BPPlugin.java
+++ b/src/main/java/jenkins/plugins/publish_over/BPPlugin.java
@@ -41,12 +41,13 @@ import org.apache.commons.lang.builder.ToStringStyle;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.TreeMap;
 
 @SuppressWarnings({ "PMD.LooseCoupling", "PMD.TooManyMethods" }) // serializable ... Map ...
-public abstract class BPPlugin<PUBLISHER extends BapPublisher, CLIENT extends BPClient, COMMON_CONFIG>
+public abstract class BPPlugin<PUBLISHER extends BapPublisher, CLIENT extends BPClient, COMMON_CONFIG extends Serializable>
             extends Notifier implements SimpleBuildStep, BPHostConfigurationAccess<CLIENT, COMMON_CONFIG> {
 
     public static final String PROMOTION_JOB_TYPE = "hudson.plugins.promoted_builds.PromotionProcess";

--- a/src/test/java/jenkins/plugins/publish_over/BPPluginTest.java
+++ b/src/test/java/jenkins/plugins/publish_over/BPPluginTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.InputStream;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.concurrent.Future;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
@@ -182,7 +183,7 @@ class BPPluginTest {
         }
     }
 
-    private static class DummyBPHostConfiguration extends BPHostConfiguration<DummyBPClient, Object> {
+    private static class DummyBPHostConfiguration extends BPHostConfiguration<DummyBPClient, Serializable> {
 
         @Override
         public DummyBPClient createClient(BPBuildInfo buildInfo) {
@@ -190,14 +191,14 @@ class BPPluginTest {
         }
     }
 
-    public static class DummyBPPlugin extends BPPlugin<BapPublisher<BPTransfer>, DummyBPClient, Object> {
+    public static class DummyBPPlugin extends BPPlugin<BapPublisher<BPTransfer>, DummyBPClient, Serializable> {
 
         public DummyBPPlugin(String consolePrefix) {
             super(consolePrefix);
         }
 
         @Override
-        public BPHostConfiguration<BPPluginTest.DummyBPClient, Object> getConfiguration(String name) {
+        public BPHostConfiguration<BPPluginTest.DummyBPClient, Serializable> getConfiguration(String name) {
             return new BPPluginTest.DummyBPHostConfiguration();
         }
 

--- a/src/test/java/jenkins/plugins/publish_over/helper/BPHostConfigurationFactory.java
+++ b/src/test/java/jenkins/plugins/publish_over/helper/BPHostConfigurationFactory.java
@@ -30,6 +30,7 @@ import jenkins.plugins.publish_over.BPClient;
 import jenkins.plugins.publish_over.BPHostConfiguration;
 
 import java.io.Serial;
+import java.io.Serializable;
 
 public class BPHostConfigurationFactory {
 
@@ -45,7 +46,7 @@ public class BPHostConfigurationFactory {
         return config;
     }
 
-    public static class ConcreteBPHostConfiguration<CLIENT extends BPClient> extends BPHostConfiguration<CLIENT, Object> {
+    public static class ConcreteBPHostConfiguration<CLIENT extends BPClient> extends BPHostConfiguration<CLIENT, Serializable> {
 
         @Serial
         private static final long serialVersionUID = 1L;


### PR DESCRIPTION
fix Jenkins 2.572's RobustReflectionConverter rejects deserializing concrete types into fields that erase to Object

issues from [Jenkins 2.572 cannot load Publish Over SSH configuration due to Object-typed commonConfig field](https://github.com/jenkinsci/publish-over-ssh-plugin/issues/423)

The downstream project [jenkinsci/publish-over-ssh-plugin](https://github.com/jenkinsci/publish-over-ssh-plugin) needs to be republished after updating its reference to this project.
### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

The change has been deployed and tested locally, and the issue is resolved.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

